### PR TITLE
Feat/#20 UserDataSetting And Solved quiz data save

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.jsoup:jsoup:1.16.1'
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '2.10.1'
     // https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15to18

--- a/src/main/java/com/example/d3nserver/common/annotation/ValidEnum.java
+++ b/src/main/java/com/example/d3nserver/common/annotation/ValidEnum.java
@@ -1,0 +1,20 @@
+package com.example.d3nserver.common.annotation;
+
+import com.example.d3nserver.common.validator.EnumValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = EnumValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+    String message() default "Invalid value. This is not permitted.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    Class<? extends java.lang.Enum<?>> enumClass();
+}

--- a/src/main/java/com/example/d3nserver/common/validator/EnumValidator.java
+++ b/src/main/java/com/example/d3nserver/common/validator/EnumValidator.java
@@ -1,0 +1,31 @@
+package com.example.d3nserver.common.validator;
+
+import com.example.d3nserver.common.annotation.ValidEnum;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.lang.annotation.Annotation;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, Enum> {
+    private ValidEnum annotation;
+
+    @Override
+    public void initialize(ValidEnum constraintAnnotation) {
+        this.annotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(Enum value, ConstraintValidatorContext context) {
+        boolean result = false;
+        Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+        if (enumValues != null) {
+            for (Object enumValue : enumValues) {
+                if (value == enumValue) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/example/d3nserver/config/SecurityConfig.java
+++ b/src/main/java/com/example/d3nserver/config/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig{
                 "/api/v1/auth/apple/login",
                 "/api/v2/auth/refresh",
                 "/api/v1/user/userForm/save",
-                "/api/v1/quiz/list/submit"
+                "/api/v1/quiz/list/submit",
+                "/api/v1/news/list"
         );
     }
     @Bean

--- a/src/main/java/com/example/d3nserver/config/SecurityConfig.java
+++ b/src/main/java/com/example/d3nserver/config/SecurityConfig.java
@@ -28,7 +28,8 @@ public class SecurityConfig{
     public WebSecurityCustomizer configure() {
         return (web) -> web.ignoring().requestMatchers(
                 "/api/v1/auth/apple/login",
-                "/api/v2/auth/refresh"
+                "/api/v2/auth/refresh",
+                "/api/v1/user/userForm/save"
         );
     }
     @Bean

--- a/src/main/java/com/example/d3nserver/config/SecurityConfig.java
+++ b/src/main/java/com/example/d3nserver/config/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig{
         return (web) -> web.ignoring().requestMatchers(
                 "/api/v1/auth/apple/login",
                 "/api/v2/auth/refresh",
-                "/api/v1/user/userForm/save"
+                "/api/v1/user/userForm/save",
+                "/api/v1/quiz/list/submit"
         );
     }
     @Bean

--- a/src/main/java/com/example/d3nserver/news/dto/NewsDTO.java
+++ b/src/main/java/com/example/d3nserver/news/dto/NewsDTO.java
@@ -1,5 +1,6 @@
 package com.example.d3nserver.news.dto;
 
+import com.example.d3nserver.common.annotation.ValidEnum;
 import com.example.d3nserver.news.domain.Field;
 import com.example.d3nserver.news.domain.News;
 import com.example.d3nserver.news.domain.NewsType;
@@ -8,6 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/example/d3nserver/news/dto/NewsResponseDto.java
+++ b/src/main/java/com/example/d3nserver/news/dto/NewsResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.d3nserver.news.dto;
 
+import com.example.d3nserver.common.annotation.ValidEnum;
 import com.example.d3nserver.news.domain.Field;
 import com.example.d3nserver.news.domain.News;
 import com.example.d3nserver.news.domain.NewsType;

--- a/src/main/java/com/example/d3nserver/quiz/controller/QuizController.java
+++ b/src/main/java/com/example/d3nserver/quiz/controller/QuizController.java
@@ -1,11 +1,14 @@
 package com.example.d3nserver.quiz.controller;
 
+import com.example.d3nserver.auth.jwt.ReqUser;
 import com.example.d3nserver.common.base.BaseResponse;
 import com.example.d3nserver.news.service.NewsService;
 import com.example.d3nserver.quiz.domain.SolvedQuiz;
 import com.example.d3nserver.quiz.dto.QuizResponseDto;
 import com.example.d3nserver.quiz.dto.SolvedQuizRequestDto;
+import com.example.d3nserver.quiz.dto.SolvedQuizResponseDto;
 import com.example.d3nserver.quiz.service.QuizService;
+import com.example.d3nserver.quiz.service.SolvedQuizService;
 import com.example.d3nserver.user.domain.User;
 import com.example.d3nserver.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +23,7 @@ import java.util.Optional;
 @RequestMapping(value="/api/v1/quiz")
 public class QuizController {
     private final QuizService quizService;
-    private final UserService userService;
+    private final SolvedQuizService solvedQuizService;
 
     @GetMapping(value = "/list")
     public BaseResponse<List<QuizResponseDto>> getQuizList(@RequestParam Long newsId){
@@ -28,7 +31,7 @@ public class QuizController {
     }
 
     @PostMapping(value = "/list/submit")
-    public BaseResponse<List<SolvedQuiz>> saveSolvedQuiz(@RequestParam("userId") String userId, @RequestBody List<SolvedQuizRequestDto> solvedQuizRequestDtoList){
-        return BaseResponse.ofSuccess(quizService.saveSolvedQuizList(userId, solvedQuizRequestDtoList));
+    public BaseResponse<List<SolvedQuizResponseDto>> submitQuiz(@ReqUser User user, @RequestBody List<SolvedQuizRequestDto> solvedQuizRequestDtoList){
+        return BaseResponse.ofSuccess(solvedQuizService.saveSolvedQuizList(user, solvedQuizRequestDtoList));
     }
 }

--- a/src/main/java/com/example/d3nserver/quiz/controller/QuizController.java
+++ b/src/main/java/com/example/d3nserver/quiz/controller/QuizController.java
@@ -2,15 +2,12 @@ package com.example.d3nserver.quiz.controller;
 
 import com.example.d3nserver.auth.jwt.ReqUser;
 import com.example.d3nserver.common.base.BaseResponse;
-import com.example.d3nserver.news.service.NewsService;
-import com.example.d3nserver.quiz.domain.SolvedQuiz;
 import com.example.d3nserver.quiz.dto.QuizResponseDto;
 import com.example.d3nserver.quiz.dto.SolvedQuizRequestDto;
 import com.example.d3nserver.quiz.dto.SolvedQuizResponseDto;
 import com.example.d3nserver.quiz.service.QuizService;
 import com.example.d3nserver.quiz.service.SolvedQuizService;
 import com.example.d3nserver.user.domain.User;
-import com.example.d3nserver.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/example/d3nserver/quiz/controller/QuizController.java
+++ b/src/main/java/com/example/d3nserver/quiz/controller/QuizController.java
@@ -1,23 +1,34 @@
 package com.example.d3nserver.quiz.controller;
 
 import com.example.d3nserver.common.base.BaseResponse;
+import com.example.d3nserver.news.service.NewsService;
+import com.example.d3nserver.quiz.domain.SolvedQuiz;
 import com.example.d3nserver.quiz.dto.QuizResponseDto;
+import com.example.d3nserver.quiz.dto.SolvedQuizRequestDto;
 import com.example.d3nserver.quiz.service.QuizService;
+import com.example.d3nserver.user.domain.User;
+import com.example.d3nserver.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value="/api/v1/quiz")
 public class QuizController {
     private final QuizService quizService;
+    private final UserService userService;
+
     @GetMapping(value = "/list")
     public BaseResponse<List<QuizResponseDto>> getQuizList(@RequestParam Long newsId){
         return BaseResponse.ofSuccess(quizService.getQuizList(newsId));
+    }
+
+    @PostMapping(value = "/list/submit")
+    public BaseResponse<List<SolvedQuiz>> saveSolvedQuiz(@RequestParam("userId") String userId, @RequestBody List<SolvedQuizRequestDto> solvedQuizRequestDtoList){
+        return BaseResponse.ofSuccess(quizService.saveSolvedQuizList(userId, solvedQuizRequestDtoList));
     }
 }

--- a/src/main/java/com/example/d3nserver/quiz/domain/Quiz.java
+++ b/src/main/java/com/example/d3nserver/quiz/domain/Quiz.java
@@ -17,13 +17,9 @@ public class Quiz extends BaseEntity{
     @ElementCollection
     private List<String> choiceList;
     private Integer answer;
-
     @ManyToOne
     @JsonBackReference
     @JoinColumn(name="news_id")
     private News news;
     private String reason;
-
-
-
 }

--- a/src/main/java/com/example/d3nserver/quiz/domain/SolvedQuiz.java
+++ b/src/main/java/com/example/d3nserver/quiz/domain/SolvedQuiz.java
@@ -1,0 +1,27 @@
+package com.example.d3nserver.quiz.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Embeddable
+public class SolvedQuiz {
+    private Long quizId;
+    private Integer selectedAnswer;
+    private Integer quizAnswer;
+
+    public SolvedQuiz(Long quizId, Integer selectedAnswer, Integer quizAnswer){
+        this.quizId = quizId;
+        this.selectedAnswer = selectedAnswer;
+        this.quizAnswer = quizAnswer;
+    }
+
+    public boolean getQuizResult(){
+        return selectedAnswer.intValue() == quizAnswer.intValue();
+    }
+}

--- a/src/main/java/com/example/d3nserver/quiz/domain/SolvedQuiz.java
+++ b/src/main/java/com/example/d3nserver/quiz/domain/SolvedQuiz.java
@@ -1,6 +1,8 @@
 package com.example.d3nserver.quiz.domain;
 
-import jakarta.persistence.Embeddable;
+import com.example.d3nserver.common.base.BaseEntity;
+import com.example.d3nserver.user.domain.User;
+import jakarta.persistence.*;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,14 +10,20 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@NoArgsConstructor
-@Embeddable
-public class SolvedQuiz {
+@Entity
+public class SolvedQuiz extends BaseEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
     private Long quizId;
     private Integer selectedAnswer;
     private Integer quizAnswer;
 
-    public SolvedQuiz(Long quizId, Integer selectedAnswer, Integer quizAnswer){
+    public SolvedQuiz(User user, Long quizId, Integer selectedAnswer, Integer quizAnswer){
+        this.user = user;
         this.quizId = quizId;
         this.selectedAnswer = selectedAnswer;
         this.quizAnswer = quizAnswer;

--- a/src/main/java/com/example/d3nserver/quiz/dto/SolvedQuizRequestDto.java
+++ b/src/main/java/com/example/d3nserver/quiz/dto/SolvedQuizRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.d3nserver.quiz.dto;
+
+import com.example.d3nserver.quiz.domain.SolvedQuiz;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class SolvedQuizRequestDto {
+    private Long quizId;
+    private Integer selectedAnswer;
+    private Integer quizAnswer;
+}

--- a/src/main/java/com/example/d3nserver/quiz/dto/SolvedQuizResponseDto.java
+++ b/src/main/java/com/example/d3nserver/quiz/dto/SolvedQuizResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.d3nserver.quiz.dto;
+
+import com.example.d3nserver.quiz.domain.SolvedQuiz;
+import lombok.Data;
+
+@Data
+public class SolvedQuizResponseDto {
+    private Long quizId;
+    private Integer selectedAnswer;
+    private Integer quizAnswer;
+
+    public SolvedQuizResponseDto(SolvedQuiz solvedQuiz){
+        this.quizId = solvedQuiz.getQuizId();
+        this.selectedAnswer = solvedQuiz.getSelectedAnswer();
+        this.quizAnswer = solvedQuiz.getQuizAnswer();
+    }
+}

--- a/src/main/java/com/example/d3nserver/quiz/repository/QuizRepository.java
+++ b/src/main/java/com/example/d3nserver/quiz/repository/QuizRepository.java
@@ -1,7 +1,5 @@
 package com.example.d3nserver.quiz.repository;
 
-import com.example.d3nserver.news.domain.Field;
-import com.example.d3nserver.news.domain.News;
 import com.example.d3nserver.quiz.domain.Quiz;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/example/d3nserver/quiz/repository/SolvedQuizRepository.java
+++ b/src/main/java/com/example/d3nserver/quiz/repository/SolvedQuizRepository.java
@@ -1,6 +1,5 @@
 package com.example.d3nserver.quiz.repository;
 
-import com.example.d3nserver.quiz.domain.Quiz;
 import com.example.d3nserver.quiz.domain.SolvedQuiz;
 import com.example.d3nserver.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/example/d3nserver/quiz/repository/SolvedQuizRepository.java
+++ b/src/main/java/com/example/d3nserver/quiz/repository/SolvedQuizRepository.java
@@ -1,0 +1,12 @@
+package com.example.d3nserver.quiz.repository;
+
+import com.example.d3nserver.quiz.domain.Quiz;
+import com.example.d3nserver.quiz.domain.SolvedQuiz;
+import com.example.d3nserver.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SolvedQuizRepository extends JpaRepository<SolvedQuiz, Integer> {
+    public List<SolvedQuiz> findAllByUser(User user);
+}

--- a/src/main/java/com/example/d3nserver/quiz/service/QuizService.java
+++ b/src/main/java/com/example/d3nserver/quiz/service/QuizService.java
@@ -1,20 +1,35 @@
 package com.example.d3nserver.quiz.service;
 
 import com.example.d3nserver.quiz.domain.Quiz;
+import com.example.d3nserver.quiz.domain.SolvedQuiz;
 import com.example.d3nserver.quiz.dto.QuizResponseDto;
+import com.example.d3nserver.quiz.dto.SolvedQuizRequestDto;
 import com.example.d3nserver.quiz.repository.QuizRepository;
+import com.example.d3nserver.user.domain.User;
+import com.example.d3nserver.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class QuizService {
     private final QuizRepository quizRepository;
+    private final UserService userService;
     public List<QuizResponseDto> getQuizList(Long newsId){
         List<Quiz> quizList = quizRepository.findAllByNewsId(newsId);
         return quizList.stream().map(QuizResponseDto::new).collect(Collectors.toList());
+    }
+
+    public List<SolvedQuiz> saveSolvedQuizList(String userId, List<SolvedQuizRequestDto> solvedQuizRequestDtoList){
+        User findUser = userService.findById(userId).get();
+        for(SolvedQuizRequestDto solvedQuizRequestDto : solvedQuizRequestDtoList){
+            findUser.getSolvedQuizList().add(new SolvedQuiz(solvedQuizRequestDto.getQuizId(), solvedQuizRequestDto.getSelectedAnswer(), solvedQuizRequestDto.getQuizAnswer()));
+        }
+        userService.save(findUser);
+        return findUser.getSolvedQuizList();
     }
 }

--- a/src/main/java/com/example/d3nserver/quiz/service/QuizService.java
+++ b/src/main/java/com/example/d3nserver/quiz/service/QuizService.java
@@ -18,18 +18,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class QuizService {
     private final QuizRepository quizRepository;
-    private final UserService userService;
+
     public List<QuizResponseDto> getQuizList(Long newsId){
         List<Quiz> quizList = quizRepository.findAllByNewsId(newsId);
         return quizList.stream().map(QuizResponseDto::new).collect(Collectors.toList());
-    }
-
-    public List<SolvedQuiz> saveSolvedQuizList(String userId, List<SolvedQuizRequestDto> solvedQuizRequestDtoList){
-        User findUser = userService.findById(userId).get();
-        for(SolvedQuizRequestDto solvedQuizRequestDto : solvedQuizRequestDtoList){
-            findUser.getSolvedQuizList().add(new SolvedQuiz(solvedQuizRequestDto.getQuizId(), solvedQuizRequestDto.getSelectedAnswer(), solvedQuizRequestDto.getQuizAnswer()));
-        }
-        userService.save(findUser);
-        return findUser.getSolvedQuizList();
     }
 }

--- a/src/main/java/com/example/d3nserver/quiz/service/SolvedQuizService.java
+++ b/src/main/java/com/example/d3nserver/quiz/service/SolvedQuizService.java
@@ -1,0 +1,38 @@
+package com.example.d3nserver.quiz.service;
+
+import com.example.d3nserver.quiz.domain.SolvedQuiz;
+import com.example.d3nserver.quiz.dto.SolvedQuizRequestDto;
+import com.example.d3nserver.quiz.dto.SolvedQuizResponseDto;
+import com.example.d3nserver.quiz.repository.SolvedQuizRepository;
+import com.example.d3nserver.user.domain.User;
+import com.example.d3nserver.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SolvedQuizService {
+    private final SolvedQuizRepository solvedQuizRepository;
+
+    public List<SolvedQuizResponseDto> saveSolvedQuizList(User user, List<SolvedQuizRequestDto> solvedQuizRequestDtoList){
+        List<SolvedQuiz> solvedQuizList = new ArrayList<>();
+        for(SolvedQuizRequestDto solvedQuizRequestDto : solvedQuizRequestDtoList){
+            SolvedQuiz solvedQuiz = new SolvedQuiz(user,solvedQuizRequestDto.getQuizId(), solvedQuizRequestDto.getSelectedAnswer(), solvedQuizRequestDto.getQuizAnswer());
+            solvedQuizList.add(solvedQuiz);
+            solvedQuizRepository.save(solvedQuiz);
+        }
+        return solvedQuizList.stream().map(SolvedQuizResponseDto::new).collect(Collectors.toList());
+    }
+
+    public List<SolvedQuizResponseDto> getUserSolvedQuizList(User user){
+        return solvedQuizRepository.findAllByUser(user).stream().map(SolvedQuizResponseDto::new).collect(Collectors.toList());
+    }
+
+    public List<SolvedQuizResponseDto> getUserIncorrectQuizList(User user){
+        return solvedQuizRepository.findAllByUser(user).stream().filter(solvedQuiz -> !solvedQuiz.getQuizResult()).map(SolvedQuizResponseDto::new).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/d3nserver/user/controller/UserController.java
+++ b/src/main/java/com/example/d3nserver/user/controller/UserController.java
@@ -21,17 +21,17 @@ public class UserController {
     private final UserService userService;
     private final SolvedQuizService solvedQuizService;
 
-    @PostMapping("/userForm/onboarding")
+    @PostMapping("/onboard")
     public BaseResponse<User> saveUserForm(@ReqUser User user, @RequestBody UserDataFormDto inputForm){
         return BaseResponse.ofSuccess(userService.saveUserForm(user,inputForm));
     }
 
-    @PostMapping("/solvedQuizList")
+    @PostMapping("/list/solved")
     public BaseResponse<List<SolvedQuizResponseDto>> getUserSolvedQuizList(@ReqUser User user){
         return BaseResponse.ofSuccess(solvedQuizService.getUserSolvedQuizList(user));
     }
 
-    @PostMapping("/incorrectQuizList")
+    @PostMapping("/list/incorrect")
     public BaseResponse<List<SolvedQuizResponseDto>> getUserIncorrectQuizList(@ReqUser User user){
         return BaseResponse.ofSuccess(solvedQuizService.getUserIncorrectQuizList(user));
     }

--- a/src/main/java/com/example/d3nserver/user/controller/UserController.java
+++ b/src/main/java/com/example/d3nserver/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.example.d3nserver.user.controller;
 
 import com.example.d3nserver.auth.jwt.ReqUser;
 import com.example.d3nserver.common.base.BaseResponse;
+import com.example.d3nserver.quiz.dto.SolvedQuizResponseDto;
+import com.example.d3nserver.quiz.service.SolvedQuizService;
 import com.example.d3nserver.user.dto.UserDataFormDto;
 import com.example.d3nserver.user.domain.User;
 import com.example.d3nserver.user.service.UserService;
@@ -9,16 +11,29 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = "/api/v1/user")
 @Slf4j
 public class UserController {
     private final UserService userService;
+    private final SolvedQuizService solvedQuizService;
 
     @PostMapping("/userForm/onboarding")
     public BaseResponse<User> saveUserForm(@ReqUser User user, @RequestBody UserDataFormDto inputForm){
         return BaseResponse.ofSuccess(userService.saveUserForm(user,inputForm));
+    }
+
+    @PostMapping("/solvedQuizList")
+    public BaseResponse<List<SolvedQuizResponseDto>> getUserSolvedQuizList(@ReqUser User user){
+        return BaseResponse.ofSuccess(solvedQuizService.getUserSolvedQuizList(user));
+    }
+
+    @PostMapping("/incorrectQuizList")
+    public BaseResponse<List<SolvedQuizResponseDto>> getUserIncorrectQuizList(@ReqUser User user){
+        return BaseResponse.ofSuccess(solvedQuizService.getUserIncorrectQuizList(user));
     }
 
 }

--- a/src/main/java/com/example/d3nserver/user/controller/UserController.java
+++ b/src/main/java/com/example/d3nserver/user/controller/UserController.java
@@ -1,12 +1,29 @@
 package com.example.d3nserver.user.controller;
 
+import com.example.d3nserver.common.base.BaseResponse;
+import com.example.d3nserver.user.dto.UserDataFormDto;
+import com.example.d3nserver.user.domain.User;
+import com.example.d3nserver.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = "/api/v1/user")
+@Slf4j
 public class UserController {
-    
+    private final UserService userService;
+
+    @PostMapping("/userForm/save")
+    public BaseResponse<User> userFormSave(@RequestBody UserDataFormDto inputForm, @RequestParam("id") String id){
+        User findUser = userService.findById(id).get();
+        findUser.setNickname(inputForm.getNickname());
+        findUser.setGender(inputForm.getGender());
+        findUser.setBirthYear(inputForm.getBirthYear());
+        findUser.setCategoryList(inputForm.getCategoryList());
+        userService.save(findUser);
+        return BaseResponse.ofSuccess(findUser);
+    }
+
 }

--- a/src/main/java/com/example/d3nserver/user/controller/UserController.java
+++ b/src/main/java/com/example/d3nserver/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.d3nserver.user.controller;
 
+import com.example.d3nserver.auth.jwt.ReqUser;
 import com.example.d3nserver.common.base.BaseResponse;
 import com.example.d3nserver.user.dto.UserDataFormDto;
 import com.example.d3nserver.user.domain.User;
@@ -15,15 +16,9 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
     private final UserService userService;
 
-    @PostMapping("/userForm/save")
-    public BaseResponse<User> userFormSave(@RequestBody UserDataFormDto inputForm, @RequestParam("id") String id){
-        User findUser = userService.findById(id).get();
-        findUser.setNickname(inputForm.getNickname());
-        findUser.setGender(inputForm.getGender());
-        findUser.setBirthYear(inputForm.getBirthYear());
-        findUser.setCategoryList(inputForm.getCategoryList());
-        userService.save(findUser);
-        return BaseResponse.ofSuccess(findUser);
+    @PostMapping("/userForm/onboarding")
+    public BaseResponse<User> saveUserForm(@ReqUser User user, @RequestBody UserDataFormDto inputForm){
+        return BaseResponse.ofSuccess(userService.saveUserForm(user,inputForm));
     }
 
 }

--- a/src/main/java/com/example/d3nserver/user/domain/User.java
+++ b/src/main/java/com/example/d3nserver/user/domain/User.java
@@ -35,8 +35,7 @@ public class User extends BaseEntity {
     private MemberProvider memberProvider;
     @Enumerated(EnumType.STRING)
     private RoleType roleType;
-    @ElementCollection
-    @Embedded
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<SolvedQuiz> solvedQuizList = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/example/d3nserver/user/domain/User.java
+++ b/src/main/java/com/example/d3nserver/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.example.d3nserver.user.domain;
 
 import com.example.d3nserver.common.base.BaseEntity;
+import com.example.d3nserver.news.domain.Field;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +22,9 @@ public class User extends BaseEntity {
     private Gender gender;
     private Integer birthYear;
     @ElementCollection
-    private List<String> categoryList;
+    @CollectionTable(name = "user_category_list", joinColumns = @JoinColumn(name = "id"))
+    @Enumerated(EnumType.STRING)
+    private List<Field> categoryList;
     @ElementCollection
     private List<Integer> scrapList;
     private String appleRefreshToken;

--- a/src/main/java/com/example/d3nserver/user/domain/User.java
+++ b/src/main/java/com/example/d3nserver/user/domain/User.java
@@ -2,11 +2,14 @@ package com.example.d3nserver.user.domain;
 
 import com.example.d3nserver.common.base.BaseEntity;
 import com.example.d3nserver.news.domain.Field;
+import com.example.d3nserver.quiz.domain.SolvedQuiz;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -22,17 +25,19 @@ public class User extends BaseEntity {
     private Gender gender;
     private Integer birthYear;
     @ElementCollection
-    @CollectionTable(name = "user_category_list", joinColumns = @JoinColumn(name = "id"))
     @Enumerated(EnumType.STRING)
-    private List<Field> categoryList;
+    private List<Field> categoryList = new ArrayList<>();
     @ElementCollection
-    private List<Integer> scrapList;
+    private List<Integer> scrapList = new ArrayList<>();
     private String appleRefreshToken;
     private String refreshToken;
     @Enumerated(EnumType.STRING)
     private MemberProvider memberProvider;
     @Enumerated(EnumType.STRING)
     private RoleType roleType;
+    @ElementCollection
+    @Embedded
+    private List<SolvedQuiz> solvedQuizList = new ArrayList<>();
 
     @Builder
     public User(String id, String appleRefreshToken, String refreshToken, MemberProvider memberProvider, RoleType roleType) {

--- a/src/main/java/com/example/d3nserver/user/domain/User.java
+++ b/src/main/java/com/example/d3nserver/user/domain/User.java
@@ -44,4 +44,5 @@ public class User extends BaseEntity {
         this.id = id;
         this.roleType = roleType;
     }
+
 }

--- a/src/main/java/com/example/d3nserver/user/dto/UserDataFormDto.java
+++ b/src/main/java/com/example/d3nserver/user/dto/UserDataFormDto.java
@@ -1,0 +1,15 @@
+package com.example.d3nserver.user.dto;
+
+import com.example.d3nserver.news.domain.Field;
+import com.example.d3nserver.user.domain.Gender;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class UserDataFormDto {
+    private String nickname;
+    private Gender gender;
+    private Integer birthYear;
+    private List<Field> categoryList;
+}

--- a/src/main/java/com/example/d3nserver/user/dto/UserDataFormDto.java
+++ b/src/main/java/com/example/d3nserver/user/dto/UserDataFormDto.java
@@ -1,5 +1,6 @@
 package com.example.d3nserver.user.dto;
 
+import com.example.d3nserver.common.annotation.ValidEnum;
 import com.example.d3nserver.news.domain.Field;
 import com.example.d3nserver.user.domain.Gender;
 import lombok.Data;
@@ -9,7 +10,9 @@ import java.util.List;
 @Data
 public class UserDataFormDto {
     private String nickname;
+    @ValidEnum(enumClass = Gender.class)
     private Gender gender;
     private Integer birthYear;
+    @ValidEnum(enumClass = Field.class)
     private List<Field> categoryList;
 }

--- a/src/main/java/com/example/d3nserver/user/service/UserService.java
+++ b/src/main/java/com/example/d3nserver/user/service/UserService.java
@@ -1,7 +1,9 @@
 package com.example.d3nserver.user.service;
 
+import com.example.d3nserver.auth.jwt.ReqUser;
 import com.example.d3nserver.user.domain.RoleType;
 import com.example.d3nserver.user.domain.User;
+import com.example.d3nserver.user.dto.UserDataFormDto;
 import com.example.d3nserver.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,5 +33,14 @@ public class UserService {
 
     public void delete(User user) {
         userRepository.delete(user);
+    }
+
+    public User saveUserForm(User user, UserDataFormDto inputForm){
+        user.setNickname(inputForm.getNickname());
+        user.setGender(inputForm.getGender());
+        user.setBirthYear(inputForm.getBirthYear());
+        user.setCategoryList(inputForm.getCategoryList());
+        save(user);
+        return user;
     }
 }

--- a/src/test/java/com/example/d3nserver/user/controller/UserControllerTest.java
+++ b/src/test/java/com/example/d3nserver/user/controller/UserControllerTest.java
@@ -1,0 +1,60 @@
+package com.example.d3nserver.user.controller;
+
+import com.example.d3nserver.news.domain.Field;
+import com.example.d3nserver.user.domain.Gender;
+import com.example.d3nserver.user.domain.User;
+import com.example.d3nserver.user.repository.UserRepository;
+import com.example.d3nserver.user.service.UserService;
+import org.junit.Ignore;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@Commit
+class UserControllerTest {
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    void userFormSave() {
+        //유저 저장
+        String testId = "abc";
+        User user = new User();
+        user.setId(testId);
+        user.setGender(Gender.MAN);
+        user.setBirthYear(1999);
+        user.setNickname(null);
+        List<Field> fields = new ArrayList<>();
+        fields.add(Field.CULTURE);
+        fields.add(Field.LIFE);
+        fields.add(Field.IT);
+        user.setCategoryList(fields);
+        User savedUser = userService.save(user);
+        User findUser = userService.findById(user.getId()).get();
+        org.assertj.core.api.Assertions.assertThat(savedUser).isEqualTo(findUser);
+    }
+
+    @Test
+    void userSave(){
+        String testId = "def";
+        User user = new User();
+        user.setId(testId);
+        User savedUser = userService.save(user);
+    }
+
+}


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
(User Data Setting)
User 도메인 세팅
애플 로그인 후, 첫 로그인 대상 사용자들에게 입력 폼을 받아 유저 데이터를 업데이트 합니다.

(SolvedQuizData)
유저가 풀었던 퀴즈에 관한 데이터를 저장합니다.
(퀴즈Id, 유저가 고른 답 인덱스, 실제 정답 인덱스)
#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
QuizService, QuizController
##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->
1. 노션에 정의했던 정답 boolean 컬럼을 사용하지 않고, SolvedQuiz 클래스에  Boolean getResult 함수를 정의
2. 유저의 social Id가 url로 넘어와도 되는지
3. 컨트롤러에 Mapping한 URL 올바른지 봐주세요 (나름대로의 규칙이 있을거 같은데, 잘 모르겠음 일단 임의로 정의함)
#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #20


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->