### PR TITLE
Feat/#33 news response edit

### DIFF
--- a/src/main/java/com/example/d3nserver/news/controller/NewsController.java
+++ b/src/main/java/com/example/d3nserver/news/controller/NewsController.java
@@ -1,9 +1,11 @@
 package com.example.d3nserver.news.controller;
 
+import com.example.d3nserver.common.annotation.ReqUser;
 import com.example.d3nserver.common.base.BaseResponse;
 import com.example.d3nserver.news.dto.NewsDTO;
 import com.example.d3nserver.news.dto.NewsResponseDto;
 import com.example.d3nserver.news.service.NewsService;
+import com.example.d3nserver.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -26,8 +28,8 @@ public class NewsController {
 
     @Operation(summary = "News list", description = "Page index와 Page 크기를 받아 뉴스 페이지를 반환한다.")
     @GetMapping("/list")
-    public BaseResponse<Page<NewsResponseDto>> getAllNews(@RequestParam @Parameter(description="페이지 인덱스, 0부터 시작")int pageIndex, @RequestParam @Parameter(description="페이지 크기")int pageSize) {
-        return BaseResponse.ofSuccess(newsService.getAllNewsDtoPageList(pageIndex, pageSize));
+    public BaseResponse<Page<NewsResponseDto>> getAllNews(@ReqUser User user, @RequestParam@Parameter(description="페이지 인덱스, 0부터 시작")int pageIndex, @RequestParam @Parameter(description="페이지 크기")int pageSize) {
+        return BaseResponse.ofSuccess(newsService.getAllNewsDtoPageList(user, pageIndex, pageSize));
     }
 
 }

--- a/src/main/java/com/example/d3nserver/news/controller/NewsController.java
+++ b/src/main/java/com/example/d3nserver/news/controller/NewsController.java
@@ -28,8 +28,8 @@ public class NewsController {
 
     @Operation(summary = "News list", description = "Page index와 Page 크기를 받아 뉴스 페이지를 반환한다.")
     @GetMapping("/list")
-    public BaseResponse<Page<NewsResponseDto>> getAllNews(@ReqUser User user, @RequestParam@Parameter(description="페이지 인덱스, 0부터 시작")int pageIndex, @RequestParam @Parameter(description="페이지 크기")int pageSize) {
-        return BaseResponse.ofSuccess(newsService.getAllNewsDtoPageList(user, pageIndex, pageSize));
+    public BaseResponse<Page<NewsResponseDto>> getAllNews(@RequestParam @Parameter(description="페이지 인덱스, 0부터 시작")int pageIndex, @RequestParam @Parameter(description="페이지 크기")int pageSize) {
+        return BaseResponse.ofSuccess(newsService.getAllNewsDtoPageListV1(pageIndex, pageSize));
     }
 
 }

--- a/src/main/java/com/example/d3nserver/news/controller/NewsV2Controller.java
+++ b/src/main/java/com/example/d3nserver/news/controller/NewsV2Controller.java
@@ -1,9 +1,11 @@
 package com.example.d3nserver.news.controller;
 
 import com.example.d3nserver.common.annotation.ApiDocumentResponse;
+import com.example.d3nserver.common.annotation.ReqUser;
 import com.example.d3nserver.common.dto.ResponseDto;
 import com.example.d3nserver.news.dto.NewsResponseDto;
 import com.example.d3nserver.news.service.NewsService;
+import com.example.d3nserver.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,8 +27,8 @@ public class NewsV2Controller {
     @ApiDocumentResponse
     @Operation(summary = "News list", description = "Page index와 Page 크기를 받아 뉴스 페이지를 반환한다.")
     @GetMapping("/list")
-    public ResponseEntity<Page<NewsResponseDto>> getAllNews(@RequestParam @Parameter(description="페이지 인덱스, 0부터 시작")int pageIndex, @RequestParam @Parameter(description="페이지 크기")int pageSize) {
-        return ResponseDto.ok(newsService.getAllNewsDtoPageList(pageIndex, pageSize));
+    public ResponseEntity<Page<NewsResponseDto>> getAllNews(@ReqUser User user, @RequestParam @Parameter(description="페이지 인덱스, 0부터 시작")int pageIndex, @RequestParam @Parameter(description="페이지 크기")int pageSize) {
+        return ResponseDto.ok(newsService.getAllNewsDtoPageList(user, pageIndex, pageSize));
     }
 
 }

--- a/src/main/java/com/example/d3nserver/news/controller/NewsV2Controller.java
+++ b/src/main/java/com/example/d3nserver/news/controller/NewsV2Controller.java
@@ -25,7 +25,7 @@ public class NewsV2Controller {
     private final NewsService newsService;
 
     @ApiDocumentResponse
-    @Operation(summary = "News list", description = "Page index와 Page 크기를 받아 뉴스 페이지를 반환한다.")
+    @Operation(summary = "News list", description = "Page index와 Page 크기를 받아 뉴스 페이지를 반환한다. (secondTime은 데이터가 없으면 0, selectedAnswer는 -1을 반환)")
     @GetMapping("/list")
     public ResponseEntity<Page<NewsResponseDto>> getAllNews(@ReqUser User user, @RequestParam @Parameter(description="페이지 인덱스, 0부터 시작")int pageIndex, @RequestParam @Parameter(description="페이지 크기")int pageSize) {
         return ResponseDto.ok(newsService.getAllNewsDtoPageList(user, pageIndex, pageSize));

--- a/src/main/java/com/example/d3nserver/news/dto/NewsResponseDto.java
+++ b/src/main/java/com/example/d3nserver/news/dto/NewsResponseDto.java
@@ -36,6 +36,7 @@ public class NewsResponseDto {
         this.mediaCompanyId = news.getMediaCompany().getId();
         this.mediaCompanyLogo = news.getMediaCompany().getLogo();
         this.mediaCompanyName = news.getMediaCompany().getName();
+        this.setSecondTime(0);
     }
 
     public String excludingHtmlTag(String htmlContent){

--- a/src/main/java/com/example/d3nserver/news/dto/NewsResponseDto.java
+++ b/src/main/java/com/example/d3nserver/news/dto/NewsResponseDto.java
@@ -8,6 +8,8 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import lombok.Data;
 
+import java.util.List;
+
 
 @Data
 public class NewsResponseDto {
@@ -20,6 +22,9 @@ public class NewsResponseDto {
     private String mediaCompanyId;
     private String mediaCompanyLogo;
     private String mediaCompanyName;
+    private Integer secondTime;
+    private List<Integer> quizAnswerList;
+    private List<Integer> selectedAnswerList;
 
     public NewsResponseDto(News news) {
         this.id = news.getId();

--- a/src/main/java/com/example/d3nserver/news/repository/NewsRepository.java
+++ b/src/main/java/com/example/d3nserver/news/repository/NewsRepository.java
@@ -13,4 +13,5 @@ import java.util.List;
 public interface NewsRepository extends JpaRepository<News, Integer> {
     List<News> findTop10ByOrderByCreatedAtDesc();
     Page<News> findAllNewsByOrderByCreatedAtDesc(Pageable pageable);
+
 }

--- a/src/main/java/com/example/d3nserver/news/repository/NewsRepository.java
+++ b/src/main/java/com/example/d3nserver/news/repository/NewsRepository.java
@@ -13,4 +13,7 @@ import java.util.List;
 public interface NewsRepository extends JpaRepository<News, Integer> {
     List<News> findTop10ByOrderByCreatedAtDesc();
     Page<News> findAllNewsByOrderByCreatedAtDesc(Pageable pageable);
+
+
+    Page<News> findAllNewsWithTimeAndQuizByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/example/d3nserver/news/service/NewsService.java
+++ b/src/main/java/com/example/d3nserver/news/service/NewsService.java
@@ -5,6 +5,7 @@ import com.example.d3nserver.news.dto.NewsDTO;
 import com.example.d3nserver.news.domain.News;
 import com.example.d3nserver.news.dto.NewsResponseDto;
 import com.example.d3nserver.news.repository.NewsRepository;
+import com.example.d3nserver.quiz.dto.response.QuizResponseDto;
 import com.example.d3nserver.quiz.service.QuizService;
 import com.example.d3nserver.time.domain.NewsReadingTime;
 import com.example.d3nserver.time.repository.NewsReadingTimeRepository;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -41,10 +43,12 @@ public class NewsService {
     }
 
     private NewsResponseDto getResponseDto(User user, News news){
-        NewsResponseDto responseDto = new NewsResponseDto(news);
-        Optional<NewsReadingTime> newsReadingTime = newsReadingTimeRepository.findByUserIdAndNewsId(user.getId(),news.getId());
-        newsReadingTime.ifPresent(value -> responseDto.setSecondTime(value.getSecondTime()));
-        
-        return responseDto;
+        NewsResponseDto newsResponseDto = new NewsResponseDto(news);
+        Optional<NewsReadingTime> newsReadingTime = newsReadingTimeRepository.findByUserIdAndNewsId(user.getId(), news.getId());
+        newsReadingTime.ifPresent(value -> newsResponseDto.setSecondTime(value.getSecondTime()));
+        List<QuizResponseDto> quizResponseDtoList = quizService.getQuizListByUser(user, news.getId());
+        newsResponseDto.setQuizAnswerList(quizResponseDtoList.stream().map(QuizResponseDto::getAnswer).collect(Collectors.toList()));
+        newsResponseDto.setSelectedAnswerList(quizResponseDtoList.stream().map(QuizResponseDto::getSelectedAnswer).collect(Collectors.toList()));
+        return newsResponseDto;
     }
 }

--- a/src/main/java/com/example/d3nserver/news/service/NewsService.java
+++ b/src/main/java/com/example/d3nserver/news/service/NewsService.java
@@ -37,10 +37,16 @@ public class NewsService {
         return todayNewsDtoList;
     }
 
+    public Page<NewsResponseDto> getAllNewsDtoPageListV1(int pageIndex, int pageSize){
+        Page<News> newsPage = newsRepository.findAllNewsByOrderByCreatedAtDesc(PageRequest.of(pageIndex, pageSize));
+        return newsPage.map(NewsResponseDto::new);
+    }
+
     public Page<NewsResponseDto> getAllNewsDtoPageList(@ReqUser User user, int pageIndex, int pageSize){
         Page<News> newsPage = newsRepository.findAllNewsByOrderByCreatedAtDesc(PageRequest.of(pageIndex, pageSize));
         return newsPage.map(news -> getResponseDto(user, news));
     }
+
 
     private NewsResponseDto getResponseDto(User user, News news){
         NewsResponseDto newsResponseDto = new NewsResponseDto(news);
@@ -49,6 +55,7 @@ public class NewsService {
         List<QuizResponseDto> quizResponseDtoList = quizService.getQuizListByUser(user, news.getId());
         newsResponseDto.setQuizAnswerList(quizResponseDtoList.stream().map(QuizResponseDto::getAnswer).collect(Collectors.toList()));
         newsResponseDto.setSelectedAnswerList(quizResponseDtoList.stream().map(QuizResponseDto::getSelectedAnswer).collect(Collectors.toList()));
+
         return newsResponseDto;
     }
 }

--- a/src/main/java/com/example/d3nserver/news/service/NewsService.java
+++ b/src/main/java/com/example/d3nserver/news/service/NewsService.java
@@ -42,7 +42,7 @@ public class NewsService {
         return newsPage.map(NewsResponseDto::new);
     }
 
-    public Page<NewsResponseDto> getAllNewsDtoPageList(@ReqUser User user, int pageIndex, int pageSize){
+    public Page<NewsResponseDto> getAllNewsDtoPageList(User user, int pageIndex, int pageSize){
         Page<News> newsPage = newsRepository.findAllNewsByOrderByCreatedAtDesc(PageRequest.of(pageIndex, pageSize));
         return newsPage.map(news -> getResponseDto(user, news));
     }

--- a/src/main/java/com/example/d3nserver/news/service/NewsService.java
+++ b/src/main/java/com/example/d3nserver/news/service/NewsService.java
@@ -1,23 +1,29 @@
 package com.example.d3nserver.news.service;
 
+import com.example.d3nserver.common.annotation.ReqUser;
 import com.example.d3nserver.news.dto.NewsDTO;
 import com.example.d3nserver.news.domain.News;
 import com.example.d3nserver.news.dto.NewsResponseDto;
 import com.example.d3nserver.news.repository.NewsRepository;
-import com.example.d3nserver.quiz.repository.QuizRepository;
 import com.example.d3nserver.quiz.service.QuizService;
+import com.example.d3nserver.time.domain.NewsReadingTime;
+import com.example.d3nserver.time.repository.NewsReadingTimeRepository;
+import com.example.d3nserver.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
 
 @Service
 @RequiredArgsConstructor
 public class NewsService {
     private final NewsRepository newsRepository;
+    private final NewsReadingTimeRepository newsReadingTimeRepository;
+    private final QuizService quizService;
 
     public List<NewsDTO> getTodayNewsDtoList(){
         List<NewsDTO> todayNewsDtoList = new ArrayList<>();
@@ -29,8 +35,16 @@ public class NewsService {
         return todayNewsDtoList;
     }
 
-    public Page<NewsResponseDto> getAllNewsDtoPageList(int pageIndex, int pageSize){
-        Page<News> allNewsPage = newsRepository.findAllNewsByOrderByCreatedAtDesc(PageRequest.of(pageIndex, pageSize));
-        return allNewsPage.map(NewsResponseDto::new);
+    public Page<NewsResponseDto> getAllNewsDtoPageList(@ReqUser User user, int pageIndex, int pageSize){
+        Page<News> newsPage = newsRepository.findAllNewsByOrderByCreatedAtDesc(PageRequest.of(pageIndex, pageSize));
+        return newsPage.map(news -> getResponseDto(user, news));
+    }
+
+    private NewsResponseDto getResponseDto(User user, News news){
+        NewsResponseDto responseDto = new NewsResponseDto(news);
+        Optional<NewsReadingTime> newsReadingTime = newsReadingTimeRepository.findByUserIdAndNewsId(user.getId(),news.getId());
+        newsReadingTime.ifPresent(value -> responseDto.setSecondTime(value.getSecondTime()));
+        
+        return responseDto;
     }
 }

--- a/src/main/java/com/example/d3nserver/news/service/NewsService.java
+++ b/src/main/java/com/example/d3nserver/news/service/NewsService.java
@@ -55,7 +55,6 @@ public class NewsService {
         List<QuizResponseDto> quizResponseDtoList = quizService.getQuizListByUser(user, news.getId());
         newsResponseDto.setQuizAnswerList(quizResponseDtoList.stream().map(QuizResponseDto::getAnswer).collect(Collectors.toList()));
         newsResponseDto.setSelectedAnswerList(quizResponseDtoList.stream().map(QuizResponseDto::getSelectedAnswer).collect(Collectors.toList()));
-
         return newsResponseDto;
     }
 }

--- a/src/main/java/com/example/d3nserver/quiz/domain/Quiz.java
+++ b/src/main/java/com/example/d3nserver/quiz/domain/Quiz.java
@@ -17,7 +17,7 @@ public class Quiz extends BaseEntity{
     @ElementCollection
     private List<String> choiceList;
     private Integer answer;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JsonBackReference
     @JoinColumn(name="news_id")
     private News news;

--- a/src/main/java/com/example/d3nserver/quiz/domain/SolvedQuiz.java
+++ b/src/main/java/com/example/d3nserver/quiz/domain/SolvedQuiz.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.util.Lazy;
 
 @Getter
 @Setter
@@ -16,10 +17,10 @@ public class SolvedQuiz extends BaseEntity {
     @Id
     @GeneratedValue
     private Long id;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "quiz_id")
     private Quiz quiz;
     private Integer selectedAnswer;

--- a/src/main/java/com/example/d3nserver/quiz/dto/response/QuizResponseDto.java
+++ b/src/main/java/com/example/d3nserver/quiz/dto/response/QuizResponseDto.java
@@ -20,5 +20,6 @@ public class QuizResponseDto {
         this.choiceList = quiz.getChoiceList();
         this.answer = quiz.getAnswer();
         this.reason = quiz.getReason();
+        this.selectedAnswer = -1;
     }
 }

--- a/src/main/java/com/example/d3nserver/quiz/dto/response/SolvedQuizResponseDto.java
+++ b/src/main/java/com/example/d3nserver/quiz/dto/response/SolvedQuizResponseDto.java
@@ -1,9 +1,7 @@
 package com.example.d3nserver.quiz.dto.response;
-
 import com.example.d3nserver.news.dto.NewsResponseDto;
 import com.example.d3nserver.quiz.domain.SolvedQuiz;
 import lombok.Data;
-
 import java.util.List;
 
 @Data

--- a/src/main/java/com/example/d3nserver/time/controller/NewsReadingTimeController.java
+++ b/src/main/java/com/example/d3nserver/time/controller/NewsReadingTimeController.java
@@ -25,7 +25,7 @@ public class NewsReadingTimeController {
 
     @ApiDocumentResponse
     @Operation(summary = "NewsReadingTime Update", description = "뉴스 읽는 시간을 갱신합니다.")
-    @PostMapping("/updatingTime")
+    @PostMapping("/time")
     public ResponseEntity<NewsReadingTimeResponseDto> updateNewsReadingTime(@ReqUser User user, @RequestBody @Parameter(description = "newsReadingTime request Dto",
             content = @Content(schema = @Schema(implementation = NewsReadingTimeRequestDto.class))) NewsReadingTimeRequestDto requestDto){
         newsReadingTimeService.updateNewsReadingTime(user,requestDto.getNewsId(),requestDto.getSecondTime());

--- a/src/main/java/com/example/d3nserver/time/controller/QuizSolvingTimeController.java
+++ b/src/main/java/com/example/d3nserver/time/controller/QuizSolvingTimeController.java
@@ -29,7 +29,7 @@ public class QuizSolvingTimeController {
 
     @ApiDocumentResponse
     @Operation(summary = "Quiz Solving Update", description = "퀴즈 푸는 시간을 갱신합니다.")
-    @PostMapping("/updatingTime")
+    @PostMapping("/time")
     public ResponseEntity<QuizSolvingTimeResponseDto> updateQuizSolvingTime(@ReqUser User user, @RequestBody @Parameter(description = "quizSolvingTime request Dto",
             content = @Content(schema = @Schema(implementation = QuizSolvingTimeRequestDto.class))) QuizSolvingTimeRequestDto requestDto){
         quizSolvingTimeService.updateQuizSolvingTime(user,requestDto.getQuizId(),requestDto.getSecondTime());

--- a/src/test/java/com/example/d3nserver/news/service/NewsServiceTest.java
+++ b/src/test/java/com/example/d3nserver/news/service/NewsServiceTest.java
@@ -13,20 +13,5 @@ import java.util.List;
 @SpringBootTest
 @Transactional
 class NewsServiceTest {
-    @Autowired
-    NewsService newsService;
 
-    @Test
-    void getTodayNewsDtoList() {
-        List<NewsDTO> todayNewsDtoList = newsService.getTodayNewsDtoList();
-    }
-
-    @Test
-    void getAllNewsDtoList(){
-        Page<NewsResponseDto> allNewsDtoPageList = newsService.getAllNewsDtoPageList(1, 3);
-        List<NewsResponseDto> content = allNewsDtoPageList.getContent();
-
-        System.out.println("title : " + content.get(1).getTitle());
-        System.out.println("summary : " + content.get(1).getSummary());
-    }
 }


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
NewsResponseDto에 유저가 뉴스를 읽은 시간, 퀴즈 답안 리스트, 유저가 선택한 답안 리스트 추가

포스트맨, 데이터 그립 테스트 완료

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->
Fetch Join을 하려면 필드를 엔티티로 매핑해야 하는데, 지금은 엔티티로 매핑하지 않고 Integer, List<Integer> 필드로 저장했어서 Fetch Join은 사용 안했습니다. 
근데 QuizResponseDto에 SolvedQuiz 쿼리도 날라가고, 뉴스마다 NewsReadingTime 쿼리도 날라갑니다.
이게 성능적으로 좋은 코드인지 걱정됩니다.

이번에 추가한 필드를 Entity 매핑으로 하고 Fetch Join을 해야할까요?

---------------------------------------------

실제 포스트맨 테스트 결과, 뉴스 페이지 받아오는데 쿼리가 많이 나갑니다.
그래서 최적화 할 수 있는 방법들을 고민해봤는데, db를 다시 설계하는게 아니면 이대로 가야할거 같습니다.

1. 연관관계가 없으면 fetch Join 사용 불가, 억지로 join 한다고 해도  join된 엔티티의 필드를 탐색할 수 없음. (반환 값을 정의된 dto를 받는 방법도 고민해봤으나, 결국 2번 때문에 안됨)
2. 연관관계를 매핑하더라도, 일대다 관계에서 Fetch Join과 페이징을 동시에 처리불가 (페이징 전 메모리에 데이터를 전부 올려놓기 때문에 일대다 관계는 fetch Join으로 Paging 불가능하다고 함)
3. @BatchSize도 테스트 해봤으나 크게 의미가 없음. (for each로 단일 값을 순회하며 쿼리를 날리기 때문에, List로 한 번에 불러오는게 아니면 의미가 없는 듯 함)

제 결론은 이러한데, 제가 잘못알고 있는거나 좋은 방법 있으면 피드백 해주세요

#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #33


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->